### PR TITLE
upd: fix select so that form value is set as value, not label;

### DIFF
--- a/src/components/Select/hooks.ts
+++ b/src/components/Select/hooks.ts
@@ -29,7 +29,7 @@ export const useSelect = (props: ISelect) => {
   };
 
   React.useEffect(() => {
-    updateFormValue(name, selectedValue, true);
+    updateFormValue(name, fieldValue, true);
     return () => {
       updateFormValue(name, '', true);
     };


### PR DESCRIPTION
**Description:** Right now, when there is an initial value in the form, `Select` component updates the form value by the label corresponding to the value. 

**Fix**: the form value should be set as actual value, not label